### PR TITLE
Add build trigger with generic webhook

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -6,6 +6,13 @@
       queue: "thoth-station/core"
       jobs:
         - "thoth-coala"
+    post:
+      jobs:
+        - "trigger-build":
+            vars:
+              cluster: "paas.psi.redhat.com"
+              namespace: "thoth-test-core"
+              buildConfigName: "workload-operator"
     kebechet-auto-gate:
       queue: "thoth-station/core"
       jobs:

--- a/openshift/buildConfig-template.yaml
+++ b/openshift/buildConfig-template.yaml
@@ -80,3 +80,7 @@ objects:
       triggers:
         - type: ImageChange
           imageChange: {}
+        - type: "Generic"
+          generic:
+            secretReference:
+              name: generic-webhook-secret


### PR DESCRIPTION
Add generic trigger webhook to buildconfig
The `generic-webhook-secret` secret is a prerequisite for using this new build config.
Add trigger build job to zuul post pipeline job list